### PR TITLE
Desktop Cart Drawer Glitches and Disappears When Adding Items Mid-Scroll

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -97,29 +97,28 @@
               {% render "icons", icon: "cart" %}
               <span>Basket</span>
             </a>
-            <div class="add-to-cart-popup">
-              <button class="add-to-cart-popup__close">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-                  <line x1="1.47819" y1="1.27422" x2="14.7413" y2="14.5373" stroke="#070D30" stroke-width="1.8"/>
-                  <line x1="14.7419" y1="1.81022" x2="1.47874" y2="15.0733" stroke="#070D30" stroke-width="1.8"/>
-                </svg>
-              </button>
-              <div class="add-to-cart-popup__inner">
-                <div class="add-to-cart-popup__arrow"></div>
-                <span class="add-to-cart-popup__title">Added to basket</span>
-                <span class="add-to-cart-popup__product-title"></span>
-                <a
-                  href="/cart"
-                  class="add-to-cart-popup__button"
-                >
-                  Go to basket
-                </a>
-              </div>
-            </div>
           </li>
         </ul>
-      </div>
-      
+      </div>      
+    </div>
+  </div>
+  <div class="add-to-cart-popup">
+    <button class="add-to-cart-popup__close">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <line x1="1.47819" y1="1.27422" x2="14.7413" y2="14.5373" stroke="#070D30" stroke-width="1.8"/>
+        <line x1="14.7419" y1="1.81022" x2="1.47874" y2="15.0733" stroke="#070D30" stroke-width="1.8"/>
+      </svg>
+    </button>
+    <div class="add-to-cart-popup__inner">
+      <div class="add-to-cart-popup__arrow"></div>
+      <span class="add-to-cart-popup__title">Added to basket</span>
+      <span class="add-to-cart-popup__product-title"></span>
+      <a
+        href="/cart"
+        class="add-to-cart-popup__button"
+      >
+        Go to basket
+      </a>
     </div>
   </div>
 


### PR DESCRIPTION
Removed` add-to-cart-popup `from parent that is being hidden when the page is scrolled to make it visible at all times.