### PR TITLE
Mobile Variant Price Does Not Update When Switching Weight

### DIFF
--- a/assets/_swatches.69f5b9b5.js
+++ b/assets/_swatches.69f5b9b5.js
@@ -331,7 +331,9 @@ class SwatchGroup {
                     available: variant.dataset.available == "true"
                 }
             });
-            document.querySelector(".product__info-wrapper [data-price]").innerHTML = toMoneyString(variant.dataset.price);
+            document.querySelectorAll(".product__price__container [data-price]").forEach((element) => {
+                element.innerHTML = toMoneyString(variant.dataset.price);
+            });
             document.dispatchEvent(variantChangedEvent);
         }
     }


### PR DESCRIPTION
This was due to different elements displaying the price in desktop and mobile. Fixed js code in updating price to select all data-price elements 